### PR TITLE
fix: update PHP test script path to use vendor directory

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
 		"start": "wp-scripts start",
 		"test:e2e": "wp-scripts test-e2e",
 		"test:unit": "wp-scripts test-unit-js",
-		"test:php": "phpunit",
+		"test:php": "./vendor/bin/phpunit",
 		"lint:php": "phpcs",
 		"lint:php:fix": "phpcbf",
 		"analyze:php": "phpstan analyze"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the command for running PHP unit tests to use the project's local PHPUnit executable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->